### PR TITLE
Remove deprecated method

### DIFF
--- a/stackoverflow/venv/lib/python3.6/site-packages/parsel/selector.py
+++ b/stackoverflow/venv/lib/python3.6/site-packages/parsel/selector.py
@@ -52,9 +52,8 @@ class SelectorList(list):
     class, which provides a few additional methods.
     """
 
-    # __getslice__ is deprecated but `list` builtin implements it only in Py2
     def __getslice__(self, i, j):
-        o = super(SelectorList, self).__getslice__(i, j)
+        o = super(SelectorList, self).__getitem__(slice(i, j))
         return self.__class__(o)
 
     def __getitem__(self, pos):


### PR DESCRIPTION
__getslice__ is deprecated since 2.0 in favour of __getitem__ with a slice() argument.