### PR TITLE
removed a pitfall where a built-in name was being shadowed

### DIFF
--- a/meizitu.py
+++ b/meizitu.py
@@ -38,9 +38,9 @@ def get_page_urls():
         baseurl = 'https://www.mzitu.com/page/{}'.format(i)
         html = request_page(baseurl)
         soup = BeautifulSoup(html, 'lxml')
-        list = soup.find(class_='postlist').find_all('li')
+        elements = soup.find(class_='postlist').find_all('li')
         urls = []
-        for item in list:
+        for item in elements:
             url = item.find('span').find('a').get('href')
             print('页面链接：%s' % url)
             urls.append(url)


### PR DESCRIPTION
**The problem**
There was a scenario on the code where a Python built-in name was being shadowed.
It's a good practice to never replace built-in methods with variables, since it may lead to hard-to-detect bugs in a scenario where the name gets invoked bearing in mind its built-in purpose instead of the newly shadowed purpose.

**Solution**
Changed the variable name 