### PR TITLE
Fix potentially vulnerable cloned function

### DIFF
--- a/stackoverflow/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_vendor/distlib/_backport/tarfile.py
+++ b/stackoverflow/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_vendor/distlib/_backport/tarfile.py
@@ -1426,6 +1426,8 @@ class TarInfo(object):
 
             length, keyword = match.groups()
             length = int(length)
+            if length == 0:
+                raise InvalidHeaderError("invalid header")
             value = buf[match.end(2) + 1:match.start(1) + length - 1]
 
             # Normally, we could just use "utf8" as the encoding and "strict"


### PR DESCRIPTION
Hi again,

Our tool identified a potential vulnerability in a clone function in `stackoverflow/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_vendor/distlib/_backport/tarfile.py` sourced from [python/cpython](https://github.com/python/cpython). This issue, originally reported in CVE-2019-20907, was resolved in the repository via this commit https://github.com/python/cpython/commit/1fa6ef2bc7cee1c8e088dd8b397d9b2d54036dbc.

This PR suggests applying the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!