### PR TITLE
Fix potentially vulnerable cloned function

### DIFF
--- a/stackoverflow/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_vendor/ipaddress.py
+++ b/stackoverflow/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_vendor/ipaddress.py
@@ -1291,6 +1291,11 @@ class _BaseV4(object):
         if len(octet_str) > 3:
             msg = "At most 3 characters permitted in %r"
             raise ValueError(msg % octet_str)
+        # Handle leading zeros as strict as glibc's inet_pton()
+        # See security bug bpo-36384
+        if octet_str != "0" and octet_str[0] == "0":
+            msg = "Leading zeros are not permitted in %r"
+            raise ValueError(msg % octet_str)
         # Convert to integer (we know digits are legal)
         octet_int = int(octet_str, 10)
         # Any octets that look like they *might* be written in octal,


### PR DESCRIPTION
Hi again,

Our tool identified a potential vulnerability in a clone function in `stackoverflow/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_vendor/ipaddress.py` sourced from [python/cpython](https://github.com/python/cpython). This issue, originally reported in CVE-2021-29921, was resolved in the repository via this commit https://github.com/python/cpython/commit/a4f6bf00297f9ca3af4dbc7b831d7bbdb3a578a7.

This PR suggests applying the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!